### PR TITLE
fix: use web component for workflow config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@nextcloud/initial-state": "^2.2.0",
 				"@nextcloud/vue": "^8.27.0",
+				"@vue/web-component-wrapper": "^1.3.0",
 				"vue": "^2.7.16"
 			},
 			"devDependencies": {
@@ -3796,6 +3797,11 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@vue/web-component-wrapper": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@vue/web-component-wrapper/-/web-component-wrapper-1.3.0.tgz",
+			"integrity": "sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA=="
 		},
 		"node_modules/@vueuse/components": {
 			"version": "11.1.0",
@@ -17262,6 +17268,11 @@
 				"@typescript-eslint/parser": "^7.1.1",
 				"vue-eslint-parser": "^9.3.1"
 			}
+		},
+		"@vue/web-component-wrapper": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@vue/web-component-wrapper/-/web-component-wrapper-1.3.0.tgz",
+			"integrity": "sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA=="
 		},
 		"@vueuse/components": {
 			"version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
 	"dependencies": {
 		"@nextcloud/initial-state": "^2.2.0",
 		"@nextcloud/vue": "^8.27.0",
+		"@vue/web-component-wrapper": "^1.3.0",
 		"vue": "^2.7.16"
 	},
 	"browserslist": [
 		"extends @nextcloud/browserslist-config"
 	],
 	"engines": {
-		"node": ">=14.0.0",
-		"npm": ">=7.0.0"
+		"node": ">=20.0.0",
+		"npm": ">=10.0.0"
 	},
 	"devDependencies": {
 		"@nextcloud/babel-config": "^1.2.0",

--- a/src/WorkflowKitinerary.vue
+++ b/src/WorkflowKitinerary.vue
@@ -16,28 +16,29 @@ export default {
 	name: 'WorkflowKitinerary',
 	components: { NcSelect },
 	props: {
-		value: {
+		modelValue: {
 			default: '',
 			type: String,
 		},
 	},
+	emits: ['update:model-value'],
 	data() {
 		const options = loadState('workflow_kitinerary', 'userCalendars')
-		let currentValue
-		if (this.value) {
-			currentValue = options[this.value]
-		} else {
-			currentValue = null
-		}
 		return {
 			options,
-			currentValue,
 		}
 	},
 	computed: {
 		placeholderString() {
 			// TRANSLATORS: Users should select a calendar for a kitinerary workflow action
 			return t('workflow_kitinerary', 'Select a calendar')
+		},
+		currentValue() {
+			if (this.modelValue) {
+				return this.options[this.modelValue]
+			} else {
+				return null
+			}
 		},
 		values() {
 			return Object.keys(this.options).map(id => {
@@ -50,10 +51,10 @@ export default {
 	},
 	methods: {
 		onInput(newValue) {
-			// when clicking on the an already selected item, we get null
+			// when clicking on the already selected item, we get null
 			// this avoids unselecting an item
 			if (newValue !== null) {
-				this.$emit('input', newValue.id)
+				this.$emit('update:model-value', newValue.id)
 			}
 		},
 	},

--- a/src/flow.js
+++ b/src/flow.js
@@ -1,8 +1,21 @@
+import wrap from '@vue/web-component-wrapper'
+import Vue from 'vue'
+
 import WorkflowKitinerary from './WorkflowKitinerary.vue'
+
+const FlowKItineraryComponent = wrap(Vue, WorkflowKitinerary)
+const customElementId = 'oca-workflow_kitinerary-operation-import'
+
+window.customElements.define(customElementId, FlowKItineraryComponent)
+
+// In Vue 2, wrap doesn't support disabling shadow :(
+// Disable with a hack
+Object.defineProperty(FlowKItineraryComponent.prototype, 'attachShadow', { value() { return this } })
+Object.defineProperty(FlowKItineraryComponent.prototype, 'shadowRoot', { get() { return this } })
 
 OCA.WorkflowEngine.registerOperator({
 	id: 'OCA\\WorkflowKitinerary\\Operation',
 	operation: '',
-	options: WorkflowKitinerary,
+	element: customElementId,
 	color: '#4d4d4d',
 })


### PR DESCRIPTION
fixes #189 

Due to some incompatibility with shipped vue versions (started with some @nextcloud/vue versions) the workflow config frontend had to be switched to work with web components instead. The previous approach was using different shipped vue versions (by server and apps) and it only worked by luck so long.

The adapation is similar to https://github.com/nextcloud/files_automatedtagging/pull/1210 and https://github.com/nextcloud/flow_notifications/pull/308. The underlying server change was https://github.com/nextcloud/server/pull/50783

Also bumped node and npm version specified in package.json as it does not build with the old ones.